### PR TITLE
use `//` for integer division

### DIFF
--- a/src/maxminddb/metadata.cr
+++ b/src/maxminddb/metadata.cr
@@ -3,12 +3,12 @@ require "./decoder"
 
 module MaxMindDB
   struct Metadata
-    # 
+    #
     private METADATA_START_MARKER = "\xAB\xCD\xEFMaxMind.com".to_slice
-    
+
     # The number of nodes in the search tree.
     getter node_count : Int32
-    
+
     # The bit size of a record in the search tree.
     getter record_size : Int32
 
@@ -23,14 +23,14 @@ module MaxMindDB
     # A value of `4` means the database only supports IPv4.
     # A database with a value of `6` may support both IPv4 and IPv6 lookups.
     getter ip_version : Int32
-    
+
     # A string identifying the database type.
     #
     # ```
     # metadata.database_type # => "GeoIP2-City"
     # ```
     getter database_type : String
-    
+
     # An array of locale codes supported by the database.
     #
     # ```
@@ -76,7 +76,7 @@ module MaxMindDB
 
       @node_count = metadata["node_count"].as_i
       @record_size = metadata["record_size"].as_i
-      @node_byte_size = @record_size / 4
+      @node_byte_size = @record_size // 4
       @search_tree_size = @node_count * @node_byte_size
       @ip_version = metadata["ip_version"].as_i
 


### PR DESCRIPTION
crystal-lang/crystal#8120 changed the behavior of `/` to always return
floats.